### PR TITLE
remove lon lat from sequencing

### DIFF
--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'DatabricksSqlSpatial',
-    version = '0.0.6',
+    version = '0.0.7',
     packages = ['DatabricksSqlSpatial'],
     package_dir = {'DatabricksSqlSpatial': '.'},
     description = '',

--- a/gems/setup.py
+++ b/gems/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 setup(
     name = 'DatabricksSqlSpatial',
-    version = '0.0.7',
+    version = '0.0.7.dev0',
     packages = ['DatabricksSqlSpatial'],
     package_dir = {'DatabricksSqlSpatial': '.'},
     description = '',

--- a/macros/PolyBuild.sql
+++ b/macros/PolyBuild.sql
@@ -37,7 +37,7 @@
 
             {# sequence key #}
             {% if has_seq -%}
-                CONCAT({{ seq }}, {{ lon }}, {{ lat }}) AS sequencing_column_name,
+                {{ seq }} AS sequencing_column_name,
             {%- else -%}
                 CONCAT({{ lon }}, {{ lat }})            AS sequencing_column_name,
             {%- endif %}

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: DatabricksSqlSpatial
 description: ''
-version: 0.0.7
+version: 0.0.7.dev0
 author: abhinav@prophecy.io
 language: sql
 buildSystem: ''

--- a/pbt_project.yml
+++ b/pbt_project.yml
@@ -1,6 +1,6 @@
 name: DatabricksSqlSpatial
 description: ''
-version: 0.0.6
+version: 0.0.7
 author: abhinav@prophecy.io
 language: sql
 buildSystem: ''


### PR DESCRIPTION
Previous PR included logic to add passthrough columns. Recreating with just sequencing change.

Concating the sequencing column with the lat and lon columns produces a string. In my case, my sequencing column was an integer and it was getting incorrectly sorted as a string:

0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12

becomes:

0, 1, 10, 11, 12, 2, 3 ...

Removing the concat and just setting sequencing_column_name as {{seq}} resolved this issue.